### PR TITLE
MappedLuns and Luns max number is not the same anymore

### DIFF
--- a/targetcli/ui_target.py
+++ b/targetcli/ui_target.py
@@ -1141,7 +1141,7 @@ class UILUNs(UINode):
                 existing_mluns = [mlun.mapped_lun for mlun in acl.mapped_luns]
                 if mapped_lun in existing_mluns:
                     mapped_lun = None
-                    for possible_mlun in six.moves.range(LUN.MAX_LUN):
+                    for possible_mlun in six.moves.range(MappedLUN.MAX_LUN):
                         if possible_mlun not in existing_mluns:
                             mapped_lun = possible_mlun
                             break


### PR DESCRIPTION
This is the targetcli change that follows the python-rtslib-fb change https://github.com/delphix/python-rtslib-fb/pull/1.

This has landed into upstream project but not in Ubuntu yet.
See original PR from upstream project: https://github.com/open-iscsi/targetcli-fb/pull/103.
