### PR TITLE
Set preference auto_save_on_exit to False by default

### DIFF
--- a/scripts/targetcli
+++ b/scripts/targetcli
@@ -48,7 +48,7 @@ class TargetCLI(ConfigShell):
                      'auto_enable_tpgt': True,
                      'auto_add_mapped_luns': True,
                      'auto_cd_after_create': False,
-                     'auto_save_on_exit': True,
+                     'auto_save_on_exit': False,
                      'auto_add_default_portal': True,
                     }
 


### PR DESCRIPTION
## Background
We use `targetcli` as a debugging tool to view the iscsi configuration. While it can be used to also modify the iscsi configuration, it should not be done. Any changes to the iscsi configuration should be done by `iscsicmd.py`, and only while the app-stack is not running to avoid inconsistencies in the configuration and/or race conditions in writing the iscsi configuration file located at `/etc/rtslib-fb-target/saveconfig.json`.

## Description
When using `targetcli`, it rewrites the configuration file (`/etc/rtslib-fb-target/saveconfig.json`) automatically on exit. This is an issue, even if there are no changes to the configuration file as this can race with other processes that want to rewrite the configuration, such as the app-stack. We prevent targetcli from rewriting the configuration by default. 

Note that the first time targetcli is run, default preferences are saved under `~/.targetcli/prefs.bin`.

## Testing
- Manually test that a modified version of `targetcli` creates preferences with `auto_save_on_exit` disabled. After the change, we do not see the following lines after exiting targetcli:
  ```
  Global pref auto_save_on_exit=true
  Last 10 configs saved in /etc/rtslib-fb-target/backup.
  Configuration saved to /etc/rtslib-fb-target/saveconfig.json
  ```
  Also verified that the timestamp of `saveconfig.json` remians unchanged
- ab-pre-push: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/1557/

fixes https://github.com/delphix/targetcli-fb/issues/2